### PR TITLE
Add support for repo README file and Swagger URL

### DIFF
--- a/resources/repository.json
+++ b/resources/repository.json
@@ -29,6 +29,19 @@
         "title": "Link",
         "icon": "DefaultProperty",
         "type": "string"
+      },
+      "documentation": {
+        "icon": "DefaultProperty",
+        "title": "Documentation",
+        "type": "string",
+        "format": "markdown"
+      },
+      "swagger_url": {
+        "title": "Swagger URL",
+        "type": "string",
+        "format": "url",
+        "spec": "async-api",
+        "icon": "DefaultProperty"
       }
     },
     "required": []


### PR DESCRIPTION
The Bitbucket Server repository blueprint does not support Documentation (Readme) and Swagger URL property. This PR adds these properties