### PR TITLE
Added support for port token refresh on expiry

### DIFF
--- a/resources/webhook_configuration.json
+++ b/resources/webhook_configuration.json
@@ -42,15 +42,15 @@
         "updated_on": ".body.pullRequest.updatedDate | (tonumber / 1000 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))",
         "merge_commit": ".body.pullRequest.fromRef.latestCommit",
         "state": ".body.pullRequest.state",
-        "owner": ".body.pullRequest.author.user.displayName",
+        "owner": ".body.pullRequest.author.user.emailAddress",
         "link": ".body.pullRequest.links.self[0].href",
         "destination": ".body.pullRequest.toRef.displayId",
         "source": ".body.pullRequest.fromRef.displayId",
-        "reviewers": "[.body.pullRequest.reviewers[].user.displayName]"
+        "reviewers": "[.body.pullRequest.reviewers[].user.emailAddress]"
       },
       "relations": {
         "repository": ".body.pullRequest.toRef.repository.slug",
-        "participants": "[.body.pullRequest.participants[].user.displayName]"
+        "participants": "[.body.pullRequest.participants[].user.emailAddress]"
       }
     }
   }


### PR DESCRIPTION
## This pull request introduces improvements to the codebase by:

- Implementing a centralized function `send_port_request` to handle all API calls to the Port API.
- Managing token refresh logic within `send_port_request`, including automatic retries on 401 Unauthorized errors.
- Refactoring existing functions to utilize `send_port_request`, thereby removing redundant error handling.