### PR TITLE
PORT-10826 Added webhook creation for older bitbucket versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ The list of variables required to run this script are:
 - `BITBUCKET_PROJECTS_FILTER` - An optional comma separated list of BitBucket projects to filter. If not provided, all projects will be fetched.
 - `WEBHOOK_SECRET` - An optional secret to use when creating a webhook in Port. If not provided, `bitbucket_webhook_secret` will be used.
 - `PORT_API_URL` - If not provided, the variable defaults to the EU Port API. For US organizations use `https://api.us.getport.io/v1` instead.
-- `IS_VERSION_8_7_OR_OLDER` - Specifies whether the Bitbucket version is older than 8.7. This setting determines if webhooks should be created at the repository level (for older versions <=8.7) or at the project level (for newer versions >=8.8).
+- `IS_VERSION_8_7_OR_OLDER` - An optional variable that specifies whether the Bitbucket version is older than 8.7. This setting determines if webhooks should be created at the repository level (for older versions <=8.7) or at the project level (for newer versions >=8.8).
 
 Done! any change that happens to your project, repository or pull requests in Bitbucket will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ export BITBUCKET_HOST=<ENTER BITBUCKET HOST>
 export BITBUCKET_PROJECTS_FILTER=<ENTER COMMA SEPARATED PROJECTS>
 export WEBHOOK_SECRET=<ENTER WEBHOOK SECRET>
 export PORT_API_URL=<ENTER PORT API URL>
+export IS_VERSION_8_7_OR_OLDER=<True>
 
 git clone https://github.com/port-labs/bitbucket-workspace-data.git
 
@@ -63,6 +64,6 @@ The list of variables required to run this script are:
 - `BITBUCKET_PROJECTS_FILTER` - An optional comma separated list of BitBucket projects to filter. If not provided, all projects will be fetched.
 - `WEBHOOK_SECRET` - An optional secret to use when creating a webhook in Port. If not provided, `bitbucket_webhook_secret` will be used.
 - `PORT_API_URL` - If not provided, the variable defaults to the EU Port API. For US organizations use `https://api.us.getport.io/v1` instead.
-
+- `IS_VERSION_8_7_OR_OLDER` - Specifies whether the Bitbucket version is older than 8.7. This setting determines if webhooks should be created at the repository level (for older versions <=8.7) or at the project level (for newer versions >=8.8).
 
 Done! any change that happens to your project, repository or pull requests in Bitbucket will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.

--- a/app.py
+++ b/app.py
@@ -514,7 +514,7 @@ async def get_repositories(project: dict[str, Any], port_webhook_url: str):
                 for repo in repositories_batch
             ]
         )
-        (
+        if IS_VERSION_8_7_OR_OLDER:
             [
                 await get_or_create_bitbucket_webhook(
                     project_key=project["key"],
@@ -524,9 +524,6 @@ async def get_repositories(project: dict[str, Any], port_webhook_url: str):
                 )
                 for repo in repositories_batch
             ]
-            if IS_VERSION_8_7_OR_OLDER
-            else None
-        )
         await get_repository_pull_requests(repository_batch=repositories_batch)
 
 
@@ -565,16 +562,12 @@ async def main():
 
         for project in projects_batch:
             await get_repositories(project=project, port_webhook_url=port_webhook_url)
-            (
+            if not IS_VERSION_8_7_OR_OLDER:
                 await get_or_create_bitbucket_webhook(
                     project_key=project["key"],
                     webhook_url=port_webhook_url,
                     events=WEBHOOK_EVENTS,
                 )
-                if not IS_VERSION_8_7_OR_OLDER
-                else None
-            )
-
     logger.info("Bitbucket data extraction completed")
     await client.aclose()
 

--- a/app.py
+++ b/app.py
@@ -208,9 +208,6 @@ async def create_project_level_webhook(
 async def create_repo_level_webhook(
     project_key: str, repo_key: str, webhook_url: str, events: list[str]
 ):
-    """
-    Create a repository-level webhook in Bitbucket.
-    """
     logger.info(f"Creating repo-level webhook for repo: {repo_key}")
     webhook_data = generate_webhook_data(webhook_url, events)
 
@@ -536,7 +533,7 @@ async def get_repositories(project: dict[str, Any], port_webhook_url: str):
 async def get_repository_pull_requests(repository_batch: list[dict[str, Any]]):
     pr_params = {"state": "ALL"}  ## Fetch all pull requests
     for repository in repository_batch:
-        pull_requests_path = f"projects/{repository['project']['key']}/repos/{repository['slug']}/pull-requests?state=all"
+        pull_requests_path = f"projects/{repository['project']['key']}/repos/{repository['slug']}/pull-requests"
         async for pull_requests_batch in get_paginated_resource(
             path=pull_requests_path, params=pr_params
         ):

--- a/app.py
+++ b/app.py
@@ -433,7 +433,7 @@ async def process_pullrequest_entities(pullrequest_data: list[dict[str, Any]]):
             "properties": {
                 "created_on": convert_to_datetime(pr.get("createdDate")),
                 "updated_on": convert_to_datetime(pr.get("updatedDate")),
-                "mergeAt": convert_to_datetime(pr.get("closedDate", 0)),
+                "mergedAt": convert_to_datetime(pr.get("closedDate", 0)),
                 "merge_commit": pr.get("fromRef", {}).get("latestCommit"),
                 "description": pr.get("description"),
                 "state": pr.get("state"),

--- a/app.py
+++ b/app.py
@@ -528,11 +528,10 @@ async def get_repositories(project: dict[str, Any], port_webhook_url: str):
 
 
 async def get_repository_pull_requests(repository_batch: list[dict[str, Any]]):
-    pr_params = {"state": "ALL"}  ## Fetch all pull requests
     for repository in repository_batch:
         pull_requests_path = f"projects/{repository['project']['key']}/repos/{repository['slug']}/pull-requests"
         async for pull_requests_batch in get_paginated_resource(
-            path=pull_requests_path, params=pr_params
+            path=pull_requests_path
         ):
             logger.info(
                 f"received pull requests batch with size {len(pull_requests_batch)} from repo: {repository['slug']}"

--- a/resources/pullrequest.json
+++ b/resources/pullrequest.json
@@ -71,6 +71,12 @@
         "title": "Merge Commit",
         "type": "string",
         "icon": "DefaultProperty"
+      },
+      "mergeAt": {
+        "title": "Merge At",
+        "type": "string",
+        "format": "date-time",
+        "icon": "DefaultProperty"
       }
     },
     "required": []

--- a/resources/pullrequest.json
+++ b/resources/pullrequest.json
@@ -72,8 +72,8 @@
         "type": "string",
         "icon": "DefaultProperty"
       },
-      "mergeAt": {
-        "title": "Merge At",
+      "mergedAt": {
+        "title": "Merged At",
         "type": "string",
         "format": "date-time",
         "icon": "DefaultProperty"

--- a/resources/webhook_configuration.json
+++ b/resources/webhook_configuration.json
@@ -46,6 +46,7 @@
         "link": ".body.pullRequest.links.self[0].href",
         "destination": ".body.pullRequest.toRef.displayId",
         "source": ".body.pullRequest.fromRef.displayId",
+        "mergedAt": ".body.pullRequest.closedDate | (tonumber / 1000 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))",
         "reviewers": "[.body.pullRequest.reviewers[].user.emailAddress]"
       },
       "relations": {


### PR DESCRIPTION
This PR introduces version-aware webhook logic to support Bitbucket versions `7.21.23` and below, which only allow webhooks at the repository level. Using a new boolean environment flag (`IS_VERSION_8_7_OR_OLDER`), the logic adapts to create webhooks at either the repository or project level.
