### PR TITLE
Added enviroment variable to support ingesting merged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,5 @@ The list of variables required to run this script are:
 - `WEBHOOK_SECRET` - An optional secret to use when creating a webhook in Port. If not provided, `bitbucket_webhook_secret` will be used.
 - `PORT_API_URL` - If not provided, the variable defaults to the EU Port API. For US organizations use `https://api.us.getport.io/v1` instead.
 - `IS_VERSION_8_7_OR_OLDER` - An optional variable that specifies whether the Bitbucket version is older than 8.7. This setting determines if webhooks should be created at the repository level (for older versions <=8.7) or at the project level (for newer versions >=8.8).
-- `GET_MERGED_PRS` - An optional variable that specifies whether the Bitbucket PR already merged should be ingested. If not provided, the variable defaults to `False`.
-
+- `PULL_REQUEST_STATE` - An optional variable to specify the state of Bitbucket pull requests to be ingested. Accepted values are `"ALL"`, `"OPEN"`, `"MERGED"`, or `"DECLINED"`. If not specified, the default value is `OPEN`.
 Done! any change that happens to your project, repository or pull requests in Bitbucket will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.

--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ The list of variables required to run this script are:
 - `WEBHOOK_SECRET` - An optional secret to use when creating a webhook in Port. If not provided, `bitbucket_webhook_secret` will be used.
 - `PORT_API_URL` - If not provided, the variable defaults to the EU Port API. For US organizations use `https://api.us.getport.io/v1` instead.
 - `IS_VERSION_8_7_OR_OLDER` - An optional variable that specifies whether the Bitbucket version is older than 8.7. This setting determines if webhooks should be created at the repository level (for older versions <=8.7) or at the project level (for newer versions >=8.8).
+- `GET_MERGED_PRS` - An optional variable that specifies whether the Bitbucket PR already merged should be ingested. If not provided, the variable defaults to `False`.
 
 Done! any change that happens to your project, repository or pull requests in Bitbucket will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.


### PR DESCRIPTION
This pull request introduces modifications focusing on enhanced support for fetching merged PRs.

## Key Changes
### Configuration Enhancements:

- Introduced `GET_MERGED_PRS` as a configurable option, allowing for flexibility in whether merged pull requests should be included in data ingestion.

- Used `params={"state": "ALL"}` in the request if `GET_MERGED_PRS` is set to `True`, enabling the ingestion of all pull request states.