### PR TITLE
PORT-11663 Updated naming for webhook to reflect webhook ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,9 +136,8 @@ async def get_or_create_port_webhook():
             return None
     else:
         webhook_url = response.json().get("integration", {}).get("url")
-        webhook_key = response.json().get("integration", {}).get("webhookKey")
         logger.info(f"Webhook configuration exists in Port. URL: {webhook_url}")
-        return webhook_url, webhook_key
+        return webhook_url
 
 
 async def create_port_webhook():
@@ -170,16 +169,15 @@ async def create_port_webhook():
         return None
     else:
         webhook_url = response.json().get("integration", {}).get("url")
-        webhook_key = response.json().get("integration", {}).get("webhookKey")
         logger.info(
             f"Webhook configuration successfully created in Port: {webhook_url}"
         )
-        return webhook_url, webhook_key
+        return webhook_url
 
 
-def generate_webhook_data(webhook_url: str, events: list[str], webhook_key: str) -> dict:
+def generate_webhook_data(webhook_url: str, events: list[str]) -> dict:
     return {
-        "name": f"Port Webhook-{webhook_key}",
+        "name": f"Port Webhook-{webhook_url.split('/')[-1]}",
         "url": webhook_url,
         "events": events,
         "active": True,
@@ -189,10 +187,10 @@ def generate_webhook_data(webhook_url: str, events: list[str], webhook_key: str)
 
 
 async def create_project_level_webhook(
-    project_key: str, webhook_url: str, events: list[str], webhook_key: str
+    project_key: str, webhook_url: str, events: list[str]
 ):
     logger.info(f"Creating project-level webhook for project: {project_key}")
-    webhook_data = generate_webhook_data(webhook_url, events, webhook_key)
+    webhook_data = generate_webhook_data(webhook_url, events)
 
     try:
         response = await client.post(
@@ -211,10 +209,10 @@ async def create_project_level_webhook(
 
 
 async def create_repo_level_webhook(
-    project_key: str, repo_key: str, webhook_url: str, events: list[str], webhook_key: str
+    project_key: str, repo_key: str, webhook_url: str, events: list[str]
 ):
     logger.info(f"Creating repo-level webhook for repo: {repo_key}")
-    webhook_data = generate_webhook_data(webhook_url, events, webhook_key)
+    webhook_data = generate_webhook_data(webhook_url, events)
 
     try:
         response = await client.post(
@@ -236,11 +234,11 @@ async def get_or_create_bitbucket_webhook(
     project_key: str,
     webhook_url: str,
     events: list[str],
-    webhook_key: str,
     repo_key: Optional[str] = None,
 ):
     logger.info(f"Checking webhooks for {repo_key or project_key}")
     if webhook_url is not None:
+        webhook_key = webhook_url.split('/')[-1]
         try:
             matching_webhooks = [
                 webhook
@@ -262,11 +260,11 @@ async def get_or_create_bitbucket_webhook(
             )
             if repo_key:
                 return await create_repo_level_webhook(
-                    project_key, repo_key, webhook_url, events, webhook_key
+                    project_key, repo_key, webhook_url, events
                 )
             else:
                 return await create_project_level_webhook(
-                    project_key, webhook_url, events, webhook_key
+                    project_key, webhook_url, events
                 )
         except httpx.HTTPStatusError as e:
             logger.error(
@@ -508,7 +506,7 @@ async def get_latest_commit(project_key: str, repo_slug: str) -> dict[str, Any]:
     return {}
 
 
-async def get_repositories(project: dict[str, Any], port_webhook_url: str, port_webhook_key: str):
+async def get_repositories(project: dict[str, Any], port_webhook_url: str):
     repositories_path = f"projects/{project['key']}/repos"
     async for repositories_batch in get_paginated_resource(path=repositories_path):
         logger.info(
@@ -531,7 +529,6 @@ async def get_repositories(project: dict[str, Any], port_webhook_url: str, port_
                     project_key=project["key"],
                     repo_key=repo["slug"],
                     webhook_url=port_webhook_url,
-                    webhook_key=port_webhook_key,
                     events=WEBHOOK_EVENTS,
                 )
                 for repo in repositories_batch
@@ -574,7 +571,7 @@ async def main():
     else:
         projects = get_paginated_resource(path=project_path)
 
-    port_webhook_url, port_webhook_key = await get_or_create_port_webhook()
+    port_webhook_url = await get_or_create_port_webhook()
     if not port_webhook_url:
         logger.error("Failed to get or create Port webhook. Skipping webhook setup...")
 
@@ -583,13 +580,12 @@ async def main():
         await process_project_entities(projects_data=projects_batch)
 
         for project in projects_batch:
-            await get_repositories(project=project, port_webhook_url=port_webhook_url, port_webhook_key=port_webhook_key)
+            await get_repositories(project=project, port_webhook_url=port_webhook_url)
             if not IS_VERSION_8_7_OR_OLDER:
                 await get_or_create_bitbucket_webhook(
                     project_key=project["key"],
                     webhook_url=port_webhook_url,
                     events=WEBHOOK_EVENTS,
-                    webhook_key=port_webhook_key,
                 )
     logger.info("Bitbucket data extraction completed")
     await client.aclose()

--- a/app.py
+++ b/app.py
@@ -238,7 +238,6 @@ async def get_or_create_bitbucket_webhook(
 ):
     logger.info(f"Checking webhooks for {repo_key or project_key}")
     if webhook_url is not None:
-        webhook_key = webhook_url.split('/')[-1]
         try:
             matching_webhooks = [
                 webhook
@@ -250,7 +249,7 @@ async def get_or_create_bitbucket_webhook(
                     )
                 )
                 for webhook in project_webhooks_batch
-                if webhook["name"] == f"Port Webhook-{webhook_key}"
+                if webhook["name"] == f"Port Webhook-{webhook_url.split('/')[-1]}"
             ]
             if matching_webhooks:
                 logger.info(f"Webhook already exists for {repo_key or project_key}.")


### PR DESCRIPTION
Previously, the name of Port's webhook in the Bitbucket environment was not unique. This has now been updated to include the webhook ID in the name, ensuring that each Port organization has a distinct webhook for data ingestion.